### PR TITLE
Fix issue #18 (Error while waching skill queue)

### DIFF
--- a/src/EVEMon/CharacterMonitoring/CharacterContactList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterContactList.cs
@@ -452,6 +452,9 @@ namespace EVEMon.CharacterMonitoring
         /// <param name="e">The <see cref="System.Windows.Forms.MouseEventArgs"/> instance containing the event data.</param>
         private void lbContacts_MouseWheel(object sender, MouseEventArgs e)
         {
+            if (e.Delta == 0)
+                return;
+
             // Update the drawing based upon the mouse wheel scrolling
             int numberOfItemLinesToMove = e.Delta * SystemInformation.MouseWheelScrollLines / Math.Abs(e.Delta);
             int lines = numberOfItemLinesToMove;

--- a/src/EVEMon/CharacterMonitoring/CharacterEmploymentHistoryList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterEmploymentHistoryList.cs
@@ -303,6 +303,9 @@ namespace EVEMon.CharacterMonitoring
         /// <param name="e">The <see cref="System.Windows.Forms.MouseEventArgs"/> instance containing the event data.</param>
         private void lbEmploymentHistory_MouseWheel(object sender, MouseEventArgs e)
         {
+            if (e.Delta == 0)
+                return;
+
             // Update the drawing based upon the mouse wheel scrolling
             int numberOfItemLinesToMove = e.Delta * SystemInformation.MouseWheelScrollLines / Math.Abs(e.Delta);
             int lines = numberOfItemLinesToMove;

--- a/src/EVEMon/CharacterMonitoring/CharacterKillLogList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterKillLogList.cs
@@ -776,6 +776,9 @@ namespace EVEMon.CharacterMonitoring
         /// <param name="e">The <see cref="System.Windows.Forms.MouseEventArgs"/> instance containing the event data.</param>
         private void lbKillLog_MouseWheel(object sender, MouseEventArgs e)
         {
+            if (e.Delta == 0)
+                return;
+
             // Update the drawing based upon the mouse wheel scrolling
             int numberOfItemLinesToMove = e.Delta * SystemInformation.MouseWheelScrollLines / Math.Abs(e.Delta);
             int lines = numberOfItemLinesToMove;

--- a/src/EVEMon/CharacterMonitoring/CharacterMedalsList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterMedalsList.cs
@@ -355,6 +355,9 @@ namespace EVEMon.CharacterMonitoring
         /// <param name="e">The <see cref="System.Windows.Forms.MouseEventArgs"/> instance containing the event data.</param>
         private void lbMedals_MouseWheel(object sender, MouseEventArgs e)
         {
+            if (e.Delta == 0)
+                return;
+
             // Update the drawing based upon the mouse wheel scrolling
             int numberOfItemLinesToMove = e.Delta * SystemInformation.MouseWheelScrollLines / Math.Abs(e.Delta);
             int lines = numberOfItemLinesToMove;

--- a/src/EVEMon/CharacterMonitoring/CharacterSkillsList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterSkillsList.cs
@@ -619,6 +619,8 @@ namespace EVEMon.CharacterMonitoring
         {
             if (!lbSkills.VerticalScrollBarVisible())
                 return;
+            if (e.Delta == 0)
+                return;
 
             // Update the drawing based upon the mouse wheel scrolling
             int numberOfItemLinesToMove = e.Delta * SystemInformation.MouseWheelScrollLines / Math.Abs(e.Delta);

--- a/src/EVEMon/CharacterMonitoring/CharacterSkillsQueueList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterSkillsQueueList.cs
@@ -438,6 +438,8 @@ namespace EVEMon.CharacterMonitoring
         {
             if (!lbSkillsQueue.VerticalScrollBarVisible())
                 return;
+            if (e.Delta == 0)
+                return;
 
             // Update the drawing based upon the mouse wheel scrolling.
             int numberOfItemLinesToMove = e.Delta * SystemInformation.MouseWheelScrollLines / Math.Abs(e.Delta);

--- a/src/EVEMon/CharacterMonitoring/CharacterStandingsList.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterStandingsList.cs
@@ -365,6 +365,9 @@ namespace EVEMon.CharacterMonitoring
         /// <param name="e">The <see cref="System.Windows.Forms.MouseEventArgs"/> instance containing the event data.</param>
         private void lbStandings_MouseWheel(object sender, MouseEventArgs e)
         {
+            if (e.Delta == 0)
+                return;
+
             // Update the drawing based upon the mouse wheel scrolling
             int numberOfItemLinesToMove = e.Delta * SystemInformation.MouseWheelScrollLines / Math.Abs(e.Delta);
             int lines = numberOfItemLinesToMove;

--- a/src/EVEMon/Controls/KillReportFittingContent.cs
+++ b/src/EVEMon/Controls/KillReportFittingContent.cs
@@ -420,6 +420,9 @@ namespace EVEMon.Controls
         /// <param name="e">The <see cref="System.Windows.Forms.MouseEventArgs"/> instance containing the event data.</param>
         private void FittingContentListBox_MouseWheel(object sender, MouseEventArgs e)
         {
+            if (e.Delta == 0)
+                return;
+
             // Update the drawing based upon the mouse wheel scrolling
             int numberOfItemLinesToMove = e.Delta * SystemInformation.MouseWheelScrollLines / Math.Abs(e.Delta);
             int lines = numberOfItemLinesToMove;


### PR DESCRIPTION
In the MouseWheel events, we were using the Delta to do a division; Although, we never check if it was not zero (which caused a DivByZero exception).

Just added a return if the delta is zero.
